### PR TITLE
SCMOD-8403: Removed unnecessary update step

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -18,7 +18,6 @@ FROM cafapi/opensuse-base:1
 
 # Update the OS packages and install NodeJS
 RUN zypper -n refresh && \
-    zypper -n update && \
     zypper -n install nodejs10 npm
 
 # Tag the image


### PR DESCRIPTION
JIRA: https://portal.digitalsafe.net/browse/SCMOD-8403
Dev build: http://sou-jenkins2.swinfra.net/job/CAFapi/view/Developer/job/CAFapi~opensuse-nodejs10-image~SCMOD-8403~CI/

Removed the update as it is in the base image with the exclusion due to the issue in [SCMOD-8403](https://portal.digitalsafe.net/browse/SCMOD-8403) and don't want to add the exclusion everywhere.